### PR TITLE
[review] puma や delayed_job の起動タイムアウト待ちを 90 秒から 30 秒に

### DIFF
--- a/templates/default/delayed_job.monitrc.erb
+++ b/templates/default/delayed_job.monitrc.erb
@@ -6,8 +6,8 @@
 
 check process delayed_job_<%= identifier.to_s %>
   with pidfile <%= pid_dir.to_s %>delayed_job.<%= n %>.pid
-  start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %> bin/delayed_job start --pid-dir=<%= pid_dir.to_s %> -i <%= n %> <%= queues.to_s %> <%= syslog.to_s %>'" with timeout 90 seconds
-  stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %> bin/delayed_job stop --pid-dir=<%= pid_dir.to_s %> -i <%= n %>'" with timeout 90 seconds
+  start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %> bin/delayed_job start --pid-dir=<%= pid_dir.to_s %> -i <%= n %> <%= queues.to_s %> <%= syslog.to_s %>'" with timeout 30 seconds
+  stop  program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map {|k,v| "#{k}=\"#{v}\""}.join(' ') %> bin/delayed_job stop --pid-dir=<%= pid_dir.to_s %> -i <%= n %>'" with timeout 30 seconds
   group delayed_job_<%= @application.to_s %>_group
 
 <% end %>

--- a/templates/default/puma.monitrc.erb
+++ b/templates/default/puma.monitrc.erb
@@ -6,7 +6,7 @@
 <% pumactl = "#{env} bundle exec pumactl -F #{config_file}"%>
 
 check process <%= @appserver_name %>_<%= @app_shortname %> with pidfile <%= pid_file %>
-start program = "/bin/sh -c 'cd <%= app_dir %> && <%= pumactl %> start | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 90 seconds
-restart program = "/bin/sh -c '(cd <%= app_dir %> && if [ -f <%= state_file %> ]; then <%= pumactl %> restart; else <%= pumactl %> start; fi) | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 90 seconds
-stop program = "/bin/sh -c 'cd <%= app_dir %> && <%= pumactl %> stop | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 90 seconds
+start program = "/bin/sh -c 'cd <%= app_dir %> && <%= pumactl %> start | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 30 seconds
+restart program = "/bin/sh -c '(cd <%= app_dir %> && if [ -f <%= state_file %> ]; then <%= pumactl %> restart; else <%= pumactl %> start; fi) | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 30 seconds
+stop program = "/bin/sh -c 'cd <%= app_dir %> && <%= pumactl %> stop | logger -t <%= @appserver_name %>-<%= @app_shortname %>'" as uid "<%= node['deployer']['user'] %>" and gid "<%= node['deployer']['group'] %>" with timeout 30 seconds
 group <%= @appserver_name %>_<%= @app_shortname.to_s %>_group


### PR DESCRIPTION
90秒だと起動待ち中に再度再起動リクエストが飛んできてしまい、それが無視されるような挙動をしたため
どこまで行ってもタイミングの調整にしかならないが、初期起動時に assets が参照できない問題を緩和するためのワークアラウンド